### PR TITLE
Non-consecutive selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "data-spreadsheet"
   ],
   "dependencies": {
-    "handsontable": "handsontable/handsontable#develop",
+    "handsontable": "github:handsontable/handsontable#feature/issue-4708",
     "hot-formula-parser": "^2.3.1",
     "moment": "2.20.1",
     "numbro": "1.11.0",

--- a/src/plugins/filters/component/condition.js
+++ b/src/plugins/filters/component/condition.js
@@ -183,7 +183,7 @@ class ConditionComponent extends BaseComponent {
   reset() {
     const lastSelectedColumn = this.hot.getPlugin('filters').getSelectedColumn();
     const visualIndex = lastSelectedColumn && lastSelectedColumn.visualIndex;
-    const columnType = this.hot.getDataType.apply(this.hot, this.hot.getSelected() || [0, visualIndex]);
+    const columnType = this.hot.getDataType.apply(this.hot, this.hot.getSelectedLast() || [0, visualIndex]);
     const items = getOptionsList(columnType);
 
     arrayEach(this.getInputElements(), (element) => element.hide());

--- a/src/plugins/filters/filters.js
+++ b/src/plugins/filters/filters.js
@@ -344,7 +344,7 @@ class Filters extends BasePlugin {
    * Clear column selection.
    */
   clearColumnSelection() {
-    let [row, col] = this.hot.getSelected() || [];
+    let [row, col] = this.hot.getSelectedLast() || [];
 
     if (row !== void 0 && col !== void 0) {
       this.hot.selectCell(row, col);

--- a/src/plugins/hiddenColumns/contextMenuItem/hideColumn.js
+++ b/src/plugins/hiddenColumns/contextMenuItem/hideColumn.js
@@ -5,7 +5,7 @@ export default function hideColumnItem(hiddenColumnsPlugin) {
   return {
     key: 'hidden_columns_hide',
     name() {
-      const selection = this.getSelected();
+      const selection = this.getSelectedLast();
       let pluralForm = 0;
 
       if (Array.isArray(selection)) {
@@ -19,7 +19,7 @@ export default function hideColumnItem(hiddenColumnsPlugin) {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_HIDE_COLUMN, pluralForm);
     },
     callback() {
-      let {from, to} = this.getSelectedRange();
+      let {from, to} = this.getSelectedRangeLast();
       let start = Math.min(from.col, to.col);
       let end = Math.max(from.col, to.col);
 

--- a/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
+++ b/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
@@ -8,7 +8,7 @@ export default function showColumnItem(hiddenColumnsPlugin) {
   return {
     key: 'hidden_columns_show',
     name() {
-      const selection = this.getSelected();
+      const selection = this.getSelectedLast();
       let pluralForm = 0;
 
       if (Array.isArray(selection)) {
@@ -37,7 +37,7 @@ export default function showColumnItem(hiddenColumnsPlugin) {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_SHOW_COLUMN, pluralForm);
     },
     callback() {
-      let {from, to} = this.getSelectedRange();
+      let {from, to} = this.getSelectedRangeLast();
       let start = Math.min(from.col, to.col);
       let end = Math.max(from.col, to.col);
 
@@ -67,7 +67,7 @@ export default function showColumnItem(hiddenColumnsPlugin) {
       beforeHiddenColumns.length = 0;
       afterHiddenColumns.length = 0;
 
-      let {from, to} = this.getSelectedRange();
+      let {from, to} = this.getSelectedRangeLast();
       let start = Math.min(from.col, to.col);
       let end = Math.max(from.col, to.col);
       let hiddenInSelection = false;

--- a/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
+++ b/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
@@ -365,15 +365,15 @@ describe('HiddenColumns', function() {
       selectCell(0, 0, 0, 0);
       keyDownUp(Handsontable.helper.KEY_CODES.ARROW_RIGHT);
 
-      expect(getSelected()).toEqual([0, 1, 0, 1]);
+      expect(getSelected()).toEqual([[0, 1, 0, 1]]);
 
       keyDownUp(Handsontable.helper.KEY_CODES.ARROW_RIGHT);
 
-      expect(getSelected()).toEqual([0, 3, 0, 3]);
+      expect(getSelected()).toEqual([[0, 3, 0, 3]]);
 
       keyDownUp(Handsontable.helper.KEY_CODES.ARROW_RIGHT);
 
-      expect(getSelected()).toEqual([0, 5, 0, 5]);
+      expect(getSelected()).toEqual([[0, 5, 0, 5]]);
     });
   });
 

--- a/src/plugins/hiddenRows/contextMenuItem/hideRow.js
+++ b/src/plugins/hiddenRows/contextMenuItem/hideRow.js
@@ -5,7 +5,7 @@ export default function hideRowItem(hiddenRowsPlugin) {
   return {
     key: 'hidden_rows_hide',
     name() {
-      const selection = this.getSelected();
+      const selection = this.getSelectedLast();
       let pluralForm = 0;
 
       if (Array.isArray(selection)) {
@@ -19,7 +19,7 @@ export default function hideRowItem(hiddenRowsPlugin) {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_HIDE_ROW, pluralForm);
     },
     callback() {
-      let {from, to} = this.getSelectedRange();
+      let {from, to} = this.getSelectedRangeLast();
       let start = Math.min(from.row, to.row);
       let end = Math.max(from.row, to.row);
 

--- a/src/plugins/hiddenRows/contextMenuItem/showRow.js
+++ b/src/plugins/hiddenRows/contextMenuItem/showRow.js
@@ -8,7 +8,7 @@ export default function showRowItem(hiddenRowsPlugin) {
   return {
     key: 'hidden_rows_show',
     name() {
-      const selection = this.getSelected();
+      const selection = this.getSelectedLast();
       let pluralForm = 0;
 
       if (Array.isArray(selection)) {
@@ -37,7 +37,7 @@ export default function showRowItem(hiddenRowsPlugin) {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_SHOW_ROW, pluralForm);
     },
     callback() {
-      let {from, to} = this.getSelectedRange();
+      let {from, to} = this.getSelectedRangeLast();
       let start = Math.min(from.row, to.row);
       let end = Math.max(from.row, to.row);
 
@@ -67,7 +67,7 @@ export default function showRowItem(hiddenRowsPlugin) {
       beforeHiddenRows.length = 0;
       afterHiddenRows.length = 0;
 
-      let {from, to} = this.getSelectedRange();
+      let {from, to} = this.getSelectedRangeLast();
       let start = Math.min(from.row, to.row);
       let end = Math.max(from.row, to.row);
 

--- a/src/plugins/hiddenRows/hiddenRows.js
+++ b/src/plugins/hiddenRows/hiddenRows.js
@@ -393,7 +393,7 @@ class HiddenRows extends BasePlugin {
    * @param {Object} coords Object with `row` and `col` properties.
    */
   onBeforeSetRangeStart(coords) {
-    let actualSelection = this.hot.getSelected() || false;
+    let actualSelection = this.hot.getSelectedLast() || false;
     let lastPossibleIndex = this.hot.countRows() - 1;
 
     let getNextRow = (row) => {

--- a/src/plugins/hiddenRows/test/hiddenRows.e2e.js
+++ b/src/plugins/hiddenRows/test/hiddenRows.e2e.js
@@ -422,15 +422,15 @@ describe('HiddenRows', function() {
       selectCell(0, 0, 0, 0);
       keyDownUp(Handsontable.helper.KEY_CODES.ARROW_DOWN);
 
-      expect(getSelected()).toEqual([1, 0, 1, 0]);
+      expect(getSelected()).toEqual([[1, 0, 1, 0]]);
 
       keyDownUp(Handsontable.helper.KEY_CODES.ARROW_DOWN);
 
-      expect(getSelected()).toEqual([3, 0, 3, 0]);
+      expect(getSelected()).toEqual([[3, 0, 3, 0]]);
 
       keyDownUp(Handsontable.helper.KEY_CODES.ARROW_DOWN);
 
-      expect(getSelected()).toEqual([5, 0, 5, 0]);
+      expect(getSelected()).toEqual([[5, 0, 5, 0]]);
     });
 
     it('should properly highlight selected cell', function() {
@@ -450,7 +450,7 @@ describe('HiddenRows', function() {
       keyDownUp(Handsontable.helper.KEY_CODES.ARROW_UP);
       keyDownUp(Handsontable.helper.KEY_CODES.ARROW_UP);
 
-      expect(hot.getSelectedRange().highlight.row).toBe(1);
+      expect(hot.getSelectedRange()[0].highlight.row).toBe(1);
     });
 
 

--- a/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/src/plugins/nestedHeaders/nestedHeaders.js
@@ -443,7 +443,7 @@ class NestedHeaders extends BasePlugin {
    * @private
    */
   updateHeadersHighlight() {
-    let selection = this.hot.getSelected();
+    let selection = this.hot.getSelectedLast();
 
     if (selection === void 0) {
       return;
@@ -536,7 +536,7 @@ class NestedHeaders extends BasePlugin {
    */
   onBeforeOnCellMouseOver(event, coords, TD, blockCalculations) {
     if (coords.row < 0 && coords.col >= 0 && this.hot.view.isMouseDown()) {
-      let {from, to} = this.hot.getSelectedRange();
+      let {from, to} = this.hot.getSelectedRangeLast();
       let colspan = this.getColspan(coords.row, coords.col);
       let lastColIndex = coords.col + colspan - 1;
       let changeDirection = false;

--- a/src/plugins/nestedHeaders/test/nestedHeaders.e2e.js
+++ b/src/plugins/nestedHeaders/test/nestedHeaders.e2e.js
@@ -277,17 +277,17 @@ describe('NestedHeaders', function() {
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(1)').simulate('mousedown');
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(1)').simulate('mouseup');
 
-      expect(hot.getSelected()).toEqual([0, 1, hot.countRows() - 1, 2]);
+      expect(hot.getSelected()).toEqual([[0, 1, hot.countRows() - 1, 2]]);
 
       this.$container.find('.ht_clone_top thead tr:eq(1) th:eq(1)').simulate('mousedown');
       this.$container.find('.ht_clone_top thead tr:eq(1) th:eq(1)').simulate('mouseup');
 
-      expect(hot.getSelected()).toEqual([0, 1, hot.countRows() - 1, 4]);
+      expect(hot.getSelected()).toEqual([[0, 1, hot.countRows() - 1, 4]]);
 
       this.$container.find('.ht_clone_top thead tr:eq(0) th:eq(1)').simulate('mousedown');
       this.$container.find('.ht_clone_top thead tr:eq(0) th:eq(1)').simulate('mouseup');
 
-      expect(hot.getSelected()).toEqual([0, 1, hot.countRows() - 1, 8]);
+      expect(hot.getSelected()).toEqual([[0, 1, hot.countRows() - 1, 8]]);
     });
 
     it('should select every column under the extended headers, when changing the selection by dragging the cursor', function() {
@@ -306,13 +306,13 @@ describe('NestedHeaders', function() {
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(5)').simulate('mouseover');
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(5)').simulate('mouseup');
 
-      expect(hot.getSelected()).toEqual([0, 3, hot.countRows() - 1, 6]);
+      expect(hot.getSelected()).toEqual([[0, 3, hot.countRows() - 1, 6]]);
 
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(3)').simulate('mousedown');
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(1)').simulate('mouseover');
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(1)').simulate('mouseup');
 
-      expect(hot.getSelected()).toEqual([0, 4, hot.countRows() - 1, 1]);
+      expect(hot.getSelected()).toEqual([[0, 4, hot.countRows() - 1, 1]]);
 
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(3)').simulate('mousedown');
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(1)').simulate('mouseover');
@@ -320,7 +320,7 @@ describe('NestedHeaders', function() {
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(5)').simulate('mouseover');
       this.$container.find('.ht_clone_top thead tr:eq(2) th:eq(5)').simulate('mouseup');
 
-      expect(hot.getSelected()).toEqual([0, 3, hot.countRows() - 1, 6]);
+      expect(hot.getSelected()).toEqual([[0, 3, hot.countRows() - 1, 6]]);
     });
 
     it('should highlight only last line of headers on cell selection', function() {

--- a/src/plugins/nestedRows/ui/contextMenu.js
+++ b/src/plugins/nestedRows/ui/contextMenu.js
@@ -46,12 +46,12 @@ class ContextMenuUI extends BaseUI {
           return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_NESTED_ROWS_INSERT_CHILD);
         },
         callback: () => {
-          const translatedRowIndex = this.dataManager.translateTrimmedRow(this.hot.getSelected()[0]);
+          const translatedRowIndex = this.dataManager.translateTrimmedRow(this.hot.getSelectedLast()[0]);
           const parent = this.dataManager.getDataObject(translatedRowIndex);
           this.dataManager.addChild(parent);
         },
         disabled: () => {
-          const selected = this.hot.getSelected();
+          const selected = this.hot.getSelectedLast();
 
           return !selected || selected[0] < 0 || this.hot.selection.selectedHeader.cols || this.hot.countRows() >= this.hot.getSettings().maxRows;
         }
@@ -62,13 +62,13 @@ class ContextMenuUI extends BaseUI {
           return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_NESTED_ROWS_DETACH_CHILD);
         },
         callback: () => {
-          const translatedRowIndex = this.dataManager.translateTrimmedRow(this.hot.getSelected()[0]);
+          const translatedRowIndex = this.dataManager.translateTrimmedRow(this.hot.getSelectedLast()[0]);
           const element = this.dataManager.getDataObject(translatedRowIndex);
 
-          this.dataManager.detachFromParent(this.hot.getSelected());
+          this.dataManager.detachFromParent(this.hot.getSelectedLast());
         },
         disabled: () => {
-          const selected = this.hot.getSelected();
+          const selected = this.hot.getSelectedLast();
           const translatedRowIndex = this.dataManager.translateTrimmedRow(selected[0]);
           let parent = this.dataManager.getRowParent(translatedRowIndex);
 

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -83,11 +83,11 @@ export function getCorrespondingOverlay(cell, container) {
  */
 export function contextMenu(cell) {
   var hot = spec().$container.data('handsontable');
-  var selected = hot.getSelected();
+  var selected = hot.getSelectedLast();
 
   if (!selected) {
     hot.selectCell(0, 0);
-    selected = hot.getSelected();
+    selected = hot.getSelectedLast();
   }
   if (!cell) {
     cell = getCell(selected[0], selected[1]);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR extends the functionality of the how cell selection works. The code contains changes which allow selecting non-consecutive cells like in the regularly excel/google spreadsheet app. 

That is why the new setting was implemented `selectionMode` which can be set as:
 - `'single'`: Only a single cell can be selected.
 - `'range'`: Multiple cells within a single range can be selected.
 - `'multiple'`: Multiple ranges of cells can be selected.

The default value is set to `'multiple'`.

The multiple selections are triggered by pressing the CTRL/CMD key.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/4708

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
