### PR TITLE
Extra `beforeDropdownMenuShow` hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "data-spreadsheet"
   ],
   "dependencies": {
-    "handsontable": "handsontable/handsontable#feature/issue-4973",
+    "handsontable": "handsontable/handsontable#develop",
     "hot-formula-parser": "^2.3.1",
     "moment": "2.20.1",
     "numbro": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "data-spreadsheet"
   ],
   "dependencies": {
-    "handsontable": "0.38.1",
+    "handsontable": "handsontable/handsontable#feature/issue-4973",
     "hot-formula-parser": "^2.3.1",
     "moment": "2.20.1",
     "numbro": "1.11.0",

--- a/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/src/plugins/dropdownMenu/dropdownMenu.js
@@ -176,6 +176,8 @@ class DropdownMenu extends BasePlugin {
    * Open menu and re-position it based on the DOM event object.
    *
    * @param {Event|Object} event Event object.
+   * @fires Hooks#beforeDropdownMenuShow
+   * @fires Hooks#afterDropdownMenuShow
    */
   open(event) {
     if (!this.menu) {

--- a/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/src/plugins/dropdownMenu/dropdownMenu.js
@@ -22,6 +22,7 @@ import {
 import './dropdownMenu.css';
 
 Hooks.getSingleton().register('afterDropdownMenuDefaultOptions');
+Hooks.getSingleton().register('beforeDropdownMenuShow');
 Hooks.getSingleton().register('afterDropdownMenuShow');
 Hooks.getSingleton().register('afterDropdownMenuHide');
 Hooks.getSingleton().register('afterDropdownMenuExecute');
@@ -131,6 +132,7 @@ class DropdownMenu extends BasePlugin {
 
       this.menu.setMenuItems(menuItems);
 
+      this.menu.addLocalHook('beforeOpen', () => this.onMenuBeforeOpen());
       this.menu.addLocalHook('afterOpen', () => this.onMenuAfterOpen());
       this.menu.addLocalHook('afterClose', () => this.onMenuAfterClose());
       this.menu.addLocalHook('executeCommand', (...params) => this.executeCommand.apply(this, params));
@@ -312,6 +314,15 @@ class DropdownMenu extends BasePlugin {
     };
 
     TH.firstChild.insertBefore(button, TH.firstChild.firstChild);
+  }
+
+  /**
+   * On menu before open listener.
+   *
+   * @private
+   */
+  onMenuBeforeOpen() {
+    this.hot.runHooks('beforeDropdownMenuShow', this);
   }
 
   /**


### PR DESCRIPTION
### Context
I may be needed to add reaction to a situation when Handsontable instance for the drop-down menu will not be yet initialized.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Manual test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. https://github.com/handsontable/handsontable-pro/issues/55
2. https://github.com/handsontable/handsontable/issues/4973

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
