### PR TITLE
Fix update of `filter_by_value` component by conditionUpdateObserver 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4805,7 +4805,7 @@
       }
     },
     "handsontable": {
-      "version": "github:handsontable/handsontable#c40f3c5f6393476a01a3bc797b33ebd00dcb280e",
+      "version": "github:handsontable/handsontable#fa64b62cbdc91c0943f2f0c4092017005caad46f",
       "requires": {
         "moment": "2.20.1",
         "numbro": "1.11.0",

--- a/src/plugins/filters/filters.js
+++ b/src/plugins/filters/filters.js
@@ -391,7 +391,9 @@ class Filters extends BasePlugin {
         const [, prop] = change;
         const columnIndex = this.hot.propToCol(prop);
 
-        this.updateValueComponentCondition(columnIndex);
+        if (this.conditionCollection.hasConditions(columnIndex)) {
+          this.updateValueComponentCondition(columnIndex);
+        }
       });
     }
   }

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -1,4 +1,4 @@
-describe('Filters UI', function() {
+describe('Filters UI', () => {
   const id = 'testContainer';
 
   beforeAll(() => {
@@ -678,7 +678,7 @@ describe('Filters UI', function() {
     });
   });
 
-  describe('"by value" component', function() {
+  describe('"by value" component', () => {
     it('should appear under dropdown menu', function() {
       handsontable({
         data: getDataForFilters(),
@@ -848,7 +848,7 @@ describe('Filters UI', function() {
       }, 100);
     });
 
-    describe('Updating "by value" component cache #87', function () {
+    describe('Updating "by value" component cache #87', () => {
       it('should update component view after applying filtering and changing cell value', function() {
         handsontable({
           data: [
@@ -892,6 +892,32 @@ describe('Filters UI', function() {
         const checkedArray = checkboxes.map((element) => element.checked);
 
         expect(checkedArray).toEqual([false, true, true]);
+      });
+
+      it('should not modify checkboxes if the user changed values in another column', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 2),
+          dropdownMenu: true,
+          colHeaders: true,
+          filters: true,
+        });
+
+        const filters = hot.getPlugin('Filters');
+
+        filters.addCondition(0, 'by_value', [['A2', 'A3', 'A4', 'A5']]);
+        filters.filter();
+        hot.selectCell(0, 1);
+        hot.emptySelectedCells();
+
+        dropdownMenu(0);
+
+        const checkboxes = $(byValueBoxRootElement()).find(':checkbox');
+
+        expect(checkboxes[0].checked).toBe(false);
+        expect(checkboxes[1].checked).toBe(true);
+        expect(checkboxes[2].checked).toBe(true);
+        expect(checkboxes[3].checked).toBe(true);
+        expect(checkboxes[4].checked).toBe(true);
       });
 
       it('should show proper number of values after refreshing cache ' +


### PR DESCRIPTION
### Context
conditionUpdateObserver updates condition stacks even if changes don't touch column with applied filter rules.

### How has this been tested?
1. Run Handsontable with below configuration:
```
{
  data: Handsontable.helper.createSpreadsheetData(5, 2),
  dropdownMenu: true,
  colHeaders: true,
  filters: true,
}
```

2. Open drop-down menu and uncheck `A1` in filter_by_value section, then apply a filter
3. Select `B2`
4. Clear selected cell
5. Open drop-down menu for column `A`
Expected: only `A1` position should be unchecked.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #72 
