### PR TITLE
Configurable BOM in file exporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@handsontable/formulajs": {
       "version": "1.2.3",
-      "resolved": "http://npm.handsoncode:4873/@handsontable%2fformulajs/-/formulajs-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@handsontable/formulajs/-/formulajs-1.2.3.tgz",
       "integrity": "sha512-jMyqkJoYoHQBnqvdbrenbmW1tOaDTG3wJnQ9lUWwC4vwELKIPRLEbYM0XI5Amvz3TBoLaksPLrWHc/avaFhpcQ==",
       "requires": {
         "bessel": "^0.2.0",
@@ -16,7 +16,7 @@
       "dependencies": {
         "numbro": {
           "version": "1.11.1",
-          "resolved": "http://npm.handsoncode:4873/numbro/-/numbro-1.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/numbro/-/numbro-1.11.1.tgz",
           "integrity": "sha512-qL0Etqbunz4RtPx4bNjMONe9HyUpgbrM4Sa3VpWY5oRdp9ry5DufAj6lCvnIcluRBA9QUacrllYc73QK0G6VAw=="
         }
       }
@@ -28,9 +28,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
-      "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -1219,7 +1219,7 @@
     },
     "bessel": {
       "version": "0.2.0",
-      "resolved": "http://npm.handsoncode:4873/bessel/-/bessel-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/bessel/-/bessel-0.2.0.tgz",
       "integrity": "sha1-E8s5zSkjMhnsLacl4LoMZvtGtvI=",
       "requires": {
         "voc": "^1.1.0"
@@ -1288,9 +1288,9 @@
       "dev": true
     },
     "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
       "dev": true,
       "requires": {
         "resolve": "1.1.7"
@@ -1538,15 +1538,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000853",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000853.tgz",
-      "integrity": "sha1-MpAafWuTqH1Z8Iqu5H6o/27JD98=",
+      "version": "1.0.30000858",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000858.tgz",
+      "integrity": "sha1-FTyTSDUGQdxiTRUOwXQmLCrZheU=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000853",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000853.tgz",
-      "integrity": "sha512-vMrE8BED4MJC9IhDJKP8ok6bJUfn5+YHvxwXMYfiPqQOJ3r2B9ihcArlUnXu6yPWf7b3jHqiEBwXZEbrbiFUqg==",
+      "version": "1.0.30000858",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000858.tgz",
+      "integrity": "sha512-oJRGfVfwHr0VKcoy2UqIoRmQcDOugnNAQsWYI3/JTzExrlzxSKtmLW1N4h+gmjgpYCEJthHmaIjok894H5il/g==",
       "dev": true
     },
     "caseless": {
@@ -1952,51 +1952,50 @@
       }
     },
     "concurrently": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.5.1.tgz",
-      "integrity": "sha512-689HrwGw8Rbk1xtV9C4dY6TPJAvIYZbRbnKSAtfJ7tHqICFGoZ0PCWYjxfmerRyxBG0o3sbG3pe7N8vqPwIHuQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.6.0.tgz",
+      "integrity": "sha512-6XiIYtYzmGEccNZFkih5JOH92jLA4ulZArAYy5j1uDSdrPLB3KzdE8GW7t2fHPcg9ry2+5LP9IEYzXzxw9lFdA==",
       "dev": true,
       "requires": {
-        "chalk": "0.5.1",
+        "chalk": "^2.4.1",
         "commander": "2.6.0",
         "date-fns": "^1.23.0",
         "lodash": "^4.5.1",
+        "read-pkg": "^3.0.0",
         "rx": "2.3.24",
         "spawn-command": "^0.0.2-1",
         "supports-color": "^3.2.3",
         "tree-kill": "^1.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
-          "dev": true
-        },
         "ansi-styles": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           },
           "dependencies": {
             "supports-color": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-              "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-              "dev": true
+              "version": "5.4.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+              "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
             }
           }
         },
@@ -2006,29 +2005,59 @@
           "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
           "dev": true
         },
-        "has-ansi": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
-        "strip-ansi": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -2037,6 +2066,14 @@
           "dev": true,
           "requires": {
             "has-flag": "^1.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
+            }
           }
         }
       }
@@ -2177,13 +2214,28 @@
       }
     },
     "cross-env": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.6.tgz",
-      "integrity": "sha512-VWTDq+G4v383SzgRS7jsAVWqEWF0aKZpDz1GVjhONvPRgHB1LnxP2sXUVFKbykHkPSnfRKS8YdiDevWFwZmQ9g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.1.0",
+        "cross-spawn": "^6.0.5",
         "is-windows": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -2734,9 +2786,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.48",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
-      "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA=",
+      "version": "1.3.50",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz",
+      "integrity": "sha1-dDi3b5K0G5GfP73TUPvQdX2s3fc=",
       "dev": true
     },
     "elliptic": {
@@ -2806,9 +2858,9 @@
       }
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -3045,9 +3097,9 @@
           "dev": true
         },
         "globals": {
-          "version": "11.5.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-          "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
           "dev": true
         },
         "js-yaml": {
@@ -3140,9 +3192,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz",
-      "integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz",
+      "integrity": "sha512-t6hGKQDMIt9N8R7vLepsYXgDfeuhp6ZJSgtrLEDxonpSubyxUZHjhm6LsAaZX8q6GYVxkbT3kTsV9G5mBCFR6A==",
       "dev": true,
       "requires": {
         "contains-path": "^0.1.0",
@@ -3698,24 +3750,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3725,12 +3781,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -3739,34 +3797,40 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3775,25 +3839,29 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3802,13 +3870,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3824,7 +3894,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3838,13 +3909,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3853,7 +3926,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3862,7 +3936,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3872,18 +3947,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -3891,13 +3969,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -3905,12 +3985,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -3919,7 +4001,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3928,7 +4011,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -3936,13 +4020,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3953,7 +4039,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3971,7 +4058,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3981,13 +4069,15 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3997,7 +4087,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4009,18 +4100,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -4028,19 +4122,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4050,19 +4147,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4074,7 +4174,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -4082,7 +4183,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4097,7 +4199,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4106,42 +4209,49 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -4151,7 +4261,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4160,7 +4271,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4168,13 +4280,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4189,13 +4303,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4204,12 +4320,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
       }
@@ -4416,7 +4534,7 @@
       }
     },
     "handsontable": {
-      "version": "github:handsontable/handsontable#1c441de2693b18bc48faac46f7bc8cf591d052fc",
+      "version": "github:handsontable/handsontable#bd17971c3a3712ed4bdc3d5e7c5e10abbea3e129",
       "from": "github:handsontable/handsontable#develop",
       "requires": {
         "moment": "2.20.1",
@@ -4585,7 +4703,7 @@
     },
     "hot-formula-parser": {
       "version": "2.3.3",
-      "resolved": "http://npm.handsoncode:4873/hot-formula-parser/-/hot-formula-parser-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/hot-formula-parser/-/hot-formula-parser-2.3.3.tgz",
       "integrity": "sha512-VNNjeqqLIEFYtVgCLrAWKunO5ndKGr9s4p65fZSpOjyPebWBnOI85oDLztVZpdVbxHJ7IU5jNeysGqFlZ98krQ==",
       "requires": {
         "@handsontable/formulajs": "^1.2.3",
@@ -4780,9 +4898,9 @@
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -4820,9 +4938,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "imurmurhash": {
@@ -5370,7 +5488,7 @@
     },
     "jStat": {
       "version": "1.7.1",
-      "resolved": "http://npm.handsoncode:4873/jStat/-/jStat-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.7.1.tgz",
       "integrity": "sha512-toueem/U5hyHM6pqe6OZOL/5P8MrY7Ss1K8Brg+TcfX+RAjDU/sbwy72fwzmLPQ5ykdBe1UEoWQHc7OSNWMUDQ=="
     },
     "jasmine-co": {
@@ -5890,6 +6008,12 @@
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -6092,6 +6216,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
     "lodash.flatten": {
@@ -6460,6 +6590,12 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+      "dev": true
+    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -6588,9 +6724,9 @@
       "dev": true
     },
     "numbro": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.0.6.tgz",
-      "integrity": "sha512-wTgLyuj1wduuHb6O/ItU/2SVR5Sf8uFVhFqbtqQU1/DqA34Wq9QqRlt0ySq1QEuju9Taq9+jPU4ExTQInYhsmA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.1.0.tgz",
+      "integrity": "sha1-YYrG5LLzLy5iMZDOSwX0yLCcMgc=",
       "requires": {
         "bignumber.js": "^4.0.4"
       }
@@ -6636,9 +6772,9 @@
       }
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
     "object-visit": {
@@ -7275,9 +7411,9 @@
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -7333,9 +7469,9 @@
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -7391,9 +7527,9 @@
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -7449,9 +7585,9 @@
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -8183,9 +8319,9 @@
       }
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
@@ -9358,7 +9494,7 @@
     },
     "tiny-emitter": {
       "version": "2.0.2",
-      "resolved": "http://npm.handsoncode:4873/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
       "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
     },
     "tmp": {
@@ -9651,9 +9787,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unset-value": {
@@ -9858,7 +9994,7 @@
     },
     "voc": {
       "version": "1.1.0",
-      "resolved": "http://npm.handsoncode:4873/voc/-/voc-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/voc/-/voc-1.1.0.tgz",
       "integrity": "sha512-fthgd8OJLqq8vPcLjElTk6Rcl2e3v5ekcXauImaqEnQqd5yUWKg1+ZOBgS2KTWuVKcuvZMQq4TDptiT1uYddUA=="
     },
     "walker": {
@@ -9939,23 +10075,24 @@
           }
         },
         "chokidar": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
           "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
             "async-each": "^1.0.0",
             "braces": "^2.3.0",
-            "fsevents": "^1.1.2",
+            "fsevents": "^1.2.2",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.1",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
             "normalize-path": "^2.1.1",
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.0.0",
-            "upath": "^1.0.0"
+            "upath": "^1.0.5"
           }
         },
         "expand-brackets": {
@@ -10500,9 +10637,9 @@
       }
     },
     "ws": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.0.tgz",
-      "integrity": "sha512-c18dMeW+PEQdDFzkhDsnBAlS4Z8KGStBQQUcQ5mf7Nf689jyGk0594L+i9RaQuf4gog6SvWLJorz2NfSaqxZ7w==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.1.tgz",
+      "integrity": "sha512-2NkHdPKjDBj3CHdnAGNpmlliryKqF+n9MYXX7/wsVC4yqYocKreKNjydPDvT3wShAZnndlM0RytEfTALCDvz7A==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"

--- a/src/plugins/exportFile/test/exportFile.e2e.js
+++ b/src/plugins/exportFile/test/exportFile.e2e.js
@@ -1,5 +1,5 @@
-describe('exportFile', function() {
-  var id = 'testContainer';
+describe('exportFile', () => {
+  const id = 'testContainer';
 
   beforeEach(function() {
     this.$container = $('<div id="' + id + '"></div>').appendTo('body');
@@ -12,14 +12,13 @@ describe('exportFile', function() {
     }
   });
 
-  describe('export options', function() {
-
-    it('should have prepared default general options', function() {
-      var hot = handsontable();
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv');
+  describe('export options', () => {
+    it('should have prepared default general options', () => {
+      handsontable();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv');
 
       expect(csv.options.filename).toMatch(/Handsontable \d+-\d+-\d+/);
-      expect(csv.options.bom).toBe('\ufeff');
+      expect(csv.options.bom).toBe(true);
       expect(csv.options.encoding).toBe('utf-8');
       expect(csv.options.columnHeaders).toBe(false);
       expect(csv.options.rowHeaders).toBe(false);
@@ -29,17 +28,16 @@ describe('exportFile', function() {
     });
   });
 
-  describe('`exportAsString` method', function() {
-
-    it('should create formatter class and call `export` method on it', function() {
-      var hot = handsontable();
-      var plugin = hot.getPlugin('exportFile');
-      var formatter = jasmine.createSpyObj('formatter', ['export']);
+  describe('`exportAsString` method', () => {
+    it('should create formatter class and call `export` method on it', () => {
+      handsontable();
+      const plugin = getPlugin('exportFile');
+      const formatter = jasmine.createSpyObj('formatter', ['export']);
 
       formatter.export.and.returnValue('foo;bar');
       spyOn(plugin, '_createTypeFormatter').and.returnValue(formatter);
 
-      var result = plugin.exportAsString('csv', {columnHeaders: true});
+      const result = plugin.exportAsString('csv', {columnHeaders: true});
 
       expect(plugin._createTypeFormatter).toHaveBeenCalledWith('csv', {columnHeaders: true});
       expect(formatter.export).toHaveBeenCalled();
@@ -47,17 +45,16 @@ describe('exportFile', function() {
     });
   });
 
-  describe('`exportAsBlob` method', function() {
-
-    it('should create formatter class and create blob object contains exported value', function() {
-      var hot = handsontable();
-      var plugin = hot.getPlugin('exportFile');
-      var formatter = jasmine.createSpy('formatter');
+  describe('`exportAsBlob` method', () => {
+    it('should create formatter class and create blob object contains exported value', () => {
+      handsontable();
+      const plugin = getPlugin('exportFile');
+      const formatter = jasmine.createSpy('formatter');
 
       spyOn(plugin, '_createTypeFormatter').and.returnValue(formatter);
       spyOn(plugin, '_createBlob').and.returnValue('blob');
 
-      var result = plugin.exportAsBlob('csv', {columnHeaders: true});
+      const result = plugin.exportAsBlob('csv', {columnHeaders: true});
 
       expect(plugin._createTypeFormatter).toHaveBeenCalledWith('csv', {columnHeaders: true});
       expect(plugin._createBlob).toHaveBeenCalledWith(formatter);
@@ -65,9 +62,8 @@ describe('exportFile', function() {
     });
   });
 
-  describe('`_createTypeFormatter` method', function() {
-
-    it('should create formatter type object', function() {
+  describe('`_createTypeFormatter` method', () => {
+    it('should create formatter type object', () => {
       var hot = handsontable();
       var plugin = hot.getPlugin('exportFile');
 
@@ -77,27 +73,26 @@ describe('exportFile', function() {
       expect(result.options.fileExtension).toBeDefined('csv');
     });
 
-    it('should throw exception when specified formatter type is not exist', function() {
-      var hot = handsontable();
-      var plugin = hot.getPlugin('exportFile');
+    it('should throw exception when specified formatter type is not exist', () => {
+      handsontable();
+      const plugin = getPlugin('exportFile');
 
-      expect(function() {
+      expect(() => {
         plugin._createTypeFormatter('csv2');
       }).toThrow();
     });
   });
 
-  describe('`_createBlob` method', function() {
-
-    it('should create blob object contains exported value', function() {
-      var hot = handsontable();
-      var plugin = hot.getPlugin('exportFile');
-      var formatter = jasmine.createSpyObj('formatter', ['export']);
+  describe('`_createBlob` method', () => {
+    it('should create blob object contains exported value', () => {
+      handsontable();
+      const plugin = getPlugin('exportFile');
+      const formatter = jasmine.createSpyObj('formatter', ['export']);
 
       formatter.export.and.returnValue('foo;bar');
       formatter.options = {mimeType: 'foo', encoding: 'iso-8859-1'};
 
-      var result = plugin._createBlob(formatter);
+      const result = plugin._createBlob(formatter);
 
       if (!Handsontable.helper.isIE9()) {
         expect(formatter.export).toHaveBeenCalled();

--- a/src/plugins/exportFile/test/exportFile.e2e.js
+++ b/src/plugins/exportFile/test/exportFile.e2e.js
@@ -19,6 +19,7 @@ describe('exportFile', function() {
       var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv');
 
       expect(csv.options.filename).toMatch(/Handsontable \d+-\d+-\d+/);
+      expect(csv.options.bom).toBe('\ufeff');
       expect(csv.options.encoding).toBe('utf-8');
       expect(csv.options.columnHeaders).toBe(false);
       expect(csv.options.rowHeaders).toBe(false);

--- a/src/plugins/exportFile/test/exportFile.e2e.js
+++ b/src/plugins/exportFile/test/exportFile.e2e.js
@@ -2,7 +2,7 @@ describe('exportFile', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $('<div id="' + id + '"></div>').appendTo('body');
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
   });
 
   afterEach(function() {

--- a/src/plugins/exportFile/test/types/csv.e2e.js
+++ b/src/plugins/exportFile/test/types/csv.e2e.js
@@ -1,12 +1,12 @@
 describe('exportFile CSV type', () => {
-  var id = 'testContainer';
+  const id = 'testContainer';
 
   function data(x, y) {
     return Handsontable.helper.createSpreadsheetData(x, y);
   };
 
   function countLines(str) {
-    var lines = str.split('\r\n');
+    const lines = str.split('\r\n');
 
     return lines.length;
   }
@@ -72,7 +72,7 @@ describe('exportFile CSV type', () => {
 
       expect(csv.options.mimeType).toBe('text/csv');
       expect(csv.options.fileExtension).toBe('csv');
-      expect(csv.options.bom).toBe('\ufeff');
+      expect(csv.options.bom).toBe(true);
       expect(csv.options.columnDelimiter).toBe(',');
       expect(csv.options.rowDelimiter).toBe('\r\n');
     });
@@ -114,7 +114,7 @@ describe('exportFile CSV type', () => {
         rowHeaders: true
       });
 
-      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {bom: ''}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {bom: false}).export();
 
       expect('A1,B1\r\nA2,B2').toBe(csv);
     });

--- a/src/plugins/exportFile/test/types/csv.e2e.js
+++ b/src/plugins/exportFile/test/types/csv.e2e.js
@@ -1,4 +1,4 @@
-describe('exportFile CSV type', function() {
+describe('exportFile CSV type', () => {
   var id = 'testContainer';
 
   function data(x, y) {
@@ -12,7 +12,7 @@ describe('exportFile CSV type', function() {
   }
 
   beforeEach(function() {
-    this.$container = $('<div id="' + id + '"></div>').appendTo('body');
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
   });
 
   afterEach(function() {
@@ -22,18 +22,18 @@ describe('exportFile CSV type', function() {
     }
   });
 
-  it('should export table when data source is defined as array of arrays', function() {
-    var hot = handsontable({
+  it('should export table when data source is defined as array of arrays', () => {
+    handsontable({
       data: [[1, 'Foo"s', 'He\nis\nvery\nkind'], [2, 'Bar"s', 'He\nis\nvery\nconfident']],
     });
 
-    var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+    const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
     expect(csv).toBe('\ufeff1,"Foo""s","He\nis\nvery\nkind"\r\n2,"Bar""s","He\nis\nvery\nconfident"');
   });
 
-  it('should export table when data source is defined as array of objects', function() {
-    var hot = handsontable({
+  it('should export table when data source is defined as array of objects', () => {
+    handsontable({
       data: [
         {
           id: 1,
@@ -53,157 +53,183 @@ describe('exportFile CSV type', function() {
       ]
     });
 
-    var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+    const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
     expect(csv).toBe('\ufeff1,"Foo""s","He\nis\nvery\nkind"\r\n2,"Bar""s","He\nis\nvery\nconfident"');
   });
 
-  it('should returns CSV type formatter object', function() {
-    var hot = handsontable();
-    var type = hot.getPlugin('exportFile')._createTypeFormatter('csv');
+  it('should returns CSV type formatter object', () => {
+    handsontable();
+    const type = getPlugin('exportFile')._createTypeFormatter('csv');
 
     expect(type).toBeDefined();
   });
 
-  describe('export options', function() {
-
-    it('should have prepared default options', function() {
-      var hot = handsontable();
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv');
+  describe('export options', () => {
+    it('should have prepared default options', () => {
+      handsontable();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv');
 
       expect(csv.options.mimeType).toBe('text/csv');
       expect(csv.options.fileExtension).toBe('csv');
+      expect(csv.options.bom).toBe('\ufeff');
       expect(csv.options.columnDelimiter).toBe(',');
       expect(csv.options.rowDelimiter).toBe('\r\n');
     });
   });
 
-  describe('`export` method', function() {
-
-    it('should returns string with corrected lines count', function() {
-      var hot = handsontable({
+  describe('`export` method', () => {
+    it('should returns string with corrected lines count', () => {
+      handsontable({
         data: data(10, 10),
         height: 396,
         colHeaders: false,
         rowHeaders: true
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
       expect(10).toBe(countLines(csv));
     });
 
-    // columnDelimiter
-    it('should export with comma as the default columnDelimiter', function() {
-      var hot = handsontable({
+    // BOM
+    it('should export with default BOM', () => {
+      handsontable({
         data: data(2, 2),
         height: 396,
         colHeaders: true,
         rowHeaders: true
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
       expect('\ufeffA1,B1\r\nA2,B2').toBe(csv);
     });
 
-    it('should export regarding to columnDelimiter option', function() {
-      var hot = handsontable({
+    it('should export without any BOM', () => {
+      handsontable({
         data: data(2, 2),
         height: 396,
         colHeaders: true,
         rowHeaders: true
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {columnDelimiter: ';'}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {bom: ''}).export();
+
+      expect('A1,B1\r\nA2,B2').toBe(csv);
+    });
+
+    // columnDelimiter
+    it('should export with comma as the default columnDelimiter', () => {
+      handsontable({
+        data: data(2, 2),
+        height: 396,
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
+
+      expect('\ufeffA1,B1\r\nA2,B2').toBe(csv);
+    });
+
+    it('should export regarding to columnDelimiter option', () => {
+      handsontable({
+        data: data(2, 2),
+        height: 396,
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {columnDelimiter: ';'}).export();
 
       expect('\ufeffA1;B1\r\nA2;B2').toBe(csv);
     });
 
     // rowDelimiter
-    it('should export with CRLF as the default rowDelimiter', function() {
-      var hot = handsontable({
+    it('should export with CRLF as the default rowDelimiter', () => {
+      handsontable({
         data: data(2, 2),
         height: 396,
         colHeaders: true,
         rowHeaders: true
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
       expect('\ufeffA1,B1\r\nA2,B2').toBe(csv);
     });
 
-    it('should export regarding to rowDelimiter option', function() {
-      var hot = handsontable({
+    it('should export regarding to rowDelimiter option', () => {
+      handsontable({
         data: data(2, 2),
         height: 396,
         colHeaders: true,
         rowHeaders: true
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {rowDelimiter: '\n'}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {rowDelimiter: '\n'}).export();
 
       expect('\ufeffA1,B1\nA2,B2').toBe(csv);
     });
 
     // columnHeaders
-    it('should export with `false` as the default columnHeaders', function() {
-      var hot = handsontable({
+    it('should export with `false` as the default columnHeaders', () => {
+      handsontable({
         data: data(2, 2),
         height: 396,
         colHeaders: true,
         rowHeaders: true
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
       expect('\ufeffA1,B1\r\nA2,B2').toBe(csv);
     });
 
-    it('should export regarding to columnHeaders option', function() {
-      var hot = handsontable({
+    it('should export regarding to columnHeaders option', () => {
+      handsontable({
         data: data(2, 2),
         height: 396,
         colHeaders: true,
         rowHeaders: true
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {columnHeaders: true}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {columnHeaders: true}).export();
 
       expect('\ufeff"A","B"\r\nA1,B1\r\nA2,B2').toBe(csv);
     });
 
     // rowHeaders
-    it('should export with `false` as the default rowHeaders', function() {
-      var hot = handsontable({
+    it('should export with `false` as the default rowHeaders', () => {
+      handsontable({
         data: data(2, 2),
         height: 396,
         colHeaders: true,
         rowHeaders: true
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
       expect('\ufeffA1,B1\r\nA2,B2').toBe(csv);
     });
 
-    it('should export regarding to rowHeaders option', function() {
-      var hot = handsontable({
+    it('should export regarding to rowHeaders option', () => {
+      handsontable({
         data: data(2, 2),
         height: 396,
         colHeaders: true,
         rowHeaders: true
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {rowHeaders: true}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {rowHeaders: true}).export();
 
       expect('\ufeff1,A1,B1\r\n2,A2,B2').toBe(csv);
     });
 
     // exportHiddenRows
-    it('should export with `false` as the default exportHiddenRows', function() {
-      var hot = handsontable({
+    it('should export with `false` as the default exportHiddenRows', () => {
+      handsontable({
         data: data(5, 2),
         height: 396,
         colHeaders: true,
@@ -214,13 +240,13 @@ describe('exportFile CSV type', function() {
         },
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
       expect('\ufeffA1,B1\r\nA4,B4').toBe(csv);
     });
 
-    it('should export regarding to exportHiddenRows option', function() {
-      var hot = handsontable({
+    it('should export regarding to exportHiddenRows option', () => {
+      handsontable({
         data: data(5, 2),
         height: 396,
         colHeaders: true,
@@ -231,14 +257,14 @@ describe('exportFile CSV type', function() {
         },
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {exportHiddenRows: true}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {exportHiddenRows: true}).export();
 
       expect('\ufeffA1,B1\r\nA2,B2\r\nA3,B3\r\nA4,B4\r\nA5,B5').toBe(csv);
     });
 
     // exportHiddenColumns
-    it('should export with `false` as the default exportHiddenColumns', function() {
-      var hot = handsontable({
+    it('should export with `false` as the default exportHiddenColumns', () => {
+      handsontable({
         data: data(2, 5),
         height: 396,
         colHeaders: true,
@@ -249,13 +275,13 @@ describe('exportFile CSV type', function() {
         },
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
       expect('\ufeffA1,D1\r\nA2,D2').toBe(csv);
     });
 
-    it('should export regarding to exportHiddenColumns option', function() {
-      var hot = handsontable({
+    it('should export regarding to exportHiddenColumns option', () => {
+      handsontable({
         data: data(2, 5),
         height: 396,
         colHeaders: true,
@@ -266,82 +292,82 @@ describe('exportFile CSV type', function() {
         },
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {exportHiddenColumns: true}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {exportHiddenColumns: true}).export();
 
       expect('\ufeffA1,B1,C1,D1,E1\r\nA2,B2,C2,D2,E2').toBe(csv);
     });
 
     // range
-    it('should export all data by default', function() {
-      var hot = handsontable({
+    it('should export all data by default', () => {
+      handsontable({
         data: data(5, 5),
         height: 396,
         colHeaders: true,
         rowHeaders: true,
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv').export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv').export();
 
       expect('\ufeffA1,B1,C1,D1,E1\r\nA2,B2,C2,D2,E2\r\nA3,B3,C3,D3,E3\r\nA4,B4,C4,D4,E4\r\nA5,B5,C5,D5,E5').toBe(csv);
     });
 
-    it('should export specified range from the middle of table', function() {
-      var hot = handsontable({
+    it('should export specified range from the middle of table', () => {
+      handsontable({
         data: data(5, 5),
         height: 396,
         colHeaders: true,
         rowHeaders: true,
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {range: [1, 1, 3, 2]}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {range: [1, 1, 3, 2]}).export();
 
       expect('\ufeffB2,C2\r\nB3,C3\r\nB4,C4').toBe(csv);
     });
 
-    it('should export only specified row', function() {
-      var hot = handsontable({
+    it('should export only specified row', () => {
+      handsontable({
         data: data(5, 5),
         height: 396,
         colHeaders: true,
         rowHeaders: true,
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {range: [1, 0, 1, 2]}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {range: [1, 0, 1, 2]}).export();
 
       expect('\ufeffA2,B2,C2').toBe(csv);
     });
 
-    it('should export only specified column', function() {
-      var hot = handsontable({
+    it('should export only specified column', () => {
+      handsontable({
         data: data(5, 5),
         height: 396,
         colHeaders: true,
         rowHeaders: true,
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {range: [0, 1, 4, 1]}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {range: [0, 1, 4, 1]}).export();
 
       expect('\ufeffB1\r\nB2\r\nB3\r\nB4\r\nB5').toBe(csv);
     });
 
-    it('should export only existing data if "range" has coordinates defined out of scope', function() {
-      var hot = handsontable({
+    it('should export only existing data if "range" has coordinates defined out of scope', () => {
+      handsontable({
         data: data(5, 5),
         height: 396,
         colHeaders: true,
         rowHeaders: true,
       });
 
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {range: [4, 3, 40, 15]}).export();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv', {range: [4, 3, 40, 15]}).export();
 
       expect('\ufeffD5,E5').toBe(csv);
     });
   });
 
-  describe('`_escapeCell` method', function() {
-    it('should not escape value if it is not necessary', function() {
-      var hot = handsontable();
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv');
+  describe('`_escapeCell` method', () => {
+    it('should not escape value if it is not necessary', () => {
+      handsontable();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv');
 
       expect(csv._escapeCell('')).toBe('');
       expect(csv._escapeCell('12345')).toBe('12345');
@@ -350,34 +376,34 @@ describe('exportFile CSV type', function() {
       expect(csv._escapeCell({})).toBe('[object Object]');
     });
 
-    it('should escape value if it includes Carriage Return (CR)', function() {
-      var hot = handsontable();
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv');
+    it('should escape value if it includes Carriage Return (CR)', () => {
+      handsontable();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv');
 
       expect(csv._escapeCell('1234\r22')).toBe('"1234\r22"');
     });
 
-    it('should escape value if it includes Double Quote (")', function() {
-      var hot = handsontable();
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv');
+    it('should escape value if it includes Double Quote (")', () => {
+      handsontable();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv');
 
       expect(csv._escapeCell('123"42')).toBe('"123""42"');
     });
 
-    it('should escape value if it includes Line Feed (LF)', function() {
-      var hot = handsontable();
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv');
+    it('should escape value if it includes Line Feed (LF)', () => {
+      handsontable();
+      const csv = getPlugin('exportFile')._createTypeFormatter('csv');
 
       expect(csv._escapeCell('123\n4')).toBe('"123\n4"');
     });
 
-    it('should escape value if it includes char defined in `columnDelimiter` option', function() {
-      var hot = handsontable();
-      var csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {columnDelimiter: ','});
+    it('should escape value if it includes char defined in `columnDelimiter` option', () => {
+      handsontable();
+      let csv = getPlugin('exportFile')._createTypeFormatter('csv', {columnDelimiter: ','});
 
       expect(csv._escapeCell('12,4')).toBe('"12,4"');
 
-      csv = hot.getPlugin('exportFile')._createTypeFormatter('csv', {columnDelimiter: ';'});
+      csv = getPlugin('exportFile')._createTypeFormatter('csv', {columnDelimiter: ';'});
 
       expect(csv._escapeCell('12;4')).toBe('"12;4"');
     });

--- a/src/plugins/exportFile/types/_base.js
+++ b/src/plugins/exportFile/types/_base.js
@@ -19,6 +19,7 @@ class BaseType {
       fileExtension: 'txt',
       filename: 'Handsontable [YYYY]-[MM]-[DD]',
       encoding: 'utf-8',
+      bom: '',
       columnHeaders: false,
       rowHeaders: false,
       exportHiddenColumns: false,

--- a/src/plugins/exportFile/types/_base.js
+++ b/src/plugins/exportFile/types/_base.js
@@ -1,6 +1,4 @@
-import {arrayEach} from 'handsontable/helpers/array';
 import {extend, clone} from 'handsontable/helpers/object';
-import {rangeEach} from 'handsontable/helpers/number';
 import {substitute} from 'handsontable/helpers/string';
 
 /**
@@ -19,7 +17,7 @@ class BaseType {
       fileExtension: 'txt',
       filename: 'Handsontable [YYYY]-[MM]-[DD]',
       encoding: 'utf-8',
-      bom: '',
+      bom: false,
       columnHeaders: false,
       rowHeaders: false,
       exportHiddenColumns: false,
@@ -59,8 +57,8 @@ class BaseType {
 
     _options.filename = substitute(_options.filename, {
       YYYY: date.getFullYear(),
-      MM: ((date.getMonth() + 1) + '').padStart(2, '0'),
-      DD: (date.getDate() + '').padStart(2, '0'),
+      MM: (`${date.getMonth() + 1}`).padStart(2, '0'),
+      DD: (`${date.getDate()}`).padStart(2, '0'),
     });
 
     return _options;

--- a/src/plugins/exportFile/types/csv.js
+++ b/src/plugins/exportFile/types/csv.js
@@ -20,6 +20,7 @@ class Csv extends BaseType {
     return {
       mimeType: 'text/csv',
       fileExtension: 'csv',
+      bom: '\ufeff',
       columnDelimiter: ',',
       rowDelimiter: '\r\n',
     };
@@ -37,9 +38,7 @@ class Csv extends BaseType {
     const hasColumnHeaders = columnHeaders.length > 0;
     let rowHeaders = this.dataProvider.getRowHeaders();
     const hasRowHeaders = rowHeaders.length > 0;
-
-    // Starts with utf-8 BOM
-    let result = '\ufeff';
+    let result = typeof options.bom === 'string' ? options.bom : '';
 
     if (hasColumnHeaders) {
       columnHeaders = arrayMap(columnHeaders, (value) => this._escapeCell(value, true));

--- a/src/plugins/exportFile/types/csv.js
+++ b/src/plugins/exportFile/types/csv.js
@@ -20,7 +20,7 @@ class Csv extends BaseType {
     return {
       mimeType: 'text/csv',
       fileExtension: 'csv',
-      bom: '\ufeff',
+      bom: true,
       columnDelimiter: ',',
       rowDelimiter: '\r\n',
     };
@@ -38,7 +38,7 @@ class Csv extends BaseType {
     const hasColumnHeaders = columnHeaders.length > 0;
     let rowHeaders = this.dataProvider.getRowHeaders();
     const hasRowHeaders = rowHeaders.length > 0;
-    let result = typeof options.bom === 'string' ? options.bom : '';
+    let result = options.bom ? String.fromCharCode(0xFEFF) : '';
 
     if (hasColumnHeaders) {
       columnHeaders = arrayMap(columnHeaders, (value) => this._escapeCell(value, true));

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -397,6 +397,7 @@ export const getDataAtRow = handsontableMethodFactory('getDataAtRow');
 export const getDataAtRowProp = handsontableMethodFactory('getDataAtRowProp');
 export const getDataType = handsontableMethodFactory('getDataType');
 export const getInstance = handsontableMethodFactory('getInstance');
+export const getPlugin = handsontableMethodFactory('getPlugin');
 export const getRowHeader = handsontableMethodFactory('getRowHeader');
 export const getSelected = handsontableMethodFactory('getSelected');
 export const getSourceData = handsontableMethodFactory('getSourceData');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@handsontable/formulajs@^1.2.3":
   version "1.2.3"
-  resolved "http://npm.handsoncode:4873/@handsontable%2fformulajs/-/formulajs-1.2.3.tgz#a98b98bc3d23832730646e3bbd6194413f8faade"
+  resolved "https://registry.yarnpkg.com/@handsontable/formulajs/-/formulajs-1.2.3.tgz#a98b98bc3d23832730646e3bbd6194413f8faade"
   dependencies:
     bessel "^0.2.0"
     jStat "^1.7.0"
@@ -45,8 +45,8 @@ acorn@^4.0.3, acorn@^4.0.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0, acorn@^5.2.1, acorn@^5.5.0:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.6.2.tgz#b1da1d7be2ac1b4a327fb9eab851702c5045b4e7"
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 agent-base@^4.1.0:
   version "4.2.0"
@@ -104,10 +104,6 @@ ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
-ansi-regex@^0.2.0, ansi-regex@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -115,10 +111,6 @@ ansi-regex@^2.0.0:
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-
-ansi-styles@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.1.0.tgz#eaecbf66cd706882760b2f4691582b8f55d7a7de"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -943,8 +935,8 @@ brorand@^1.0.1:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
 browser-resolve@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
   dependencies:
     resolve "1.1.7"
 
@@ -1125,12 +1117,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000853"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000853.tgz#32901a7d6b93a87d59f08aaee47ea8ff6ec90fdf"
+  version "1.0.30000858"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000858.tgz#153c9348350641dc624d150ec174262c2ad985e5"
 
 caniuse-lite@^1.0.30000844:
-  version "1.0.30000853"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000853.tgz#505249fc78d60e20ad47af3c13706d6f9fd209fd"
+  version "1.0.30000858"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000858.tgz#f6f203a9128bac507136de1cf6cfd966d2df027c"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1142,16 +1134,6 @@ center-align@^0.1.1:
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
-
-chalk@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
-  dependencies:
-    ansi-styles "^1.1.0"
-    escape-string-regexp "^1.0.0"
-    has-ansi "^0.1.0"
-    strip-ansi "^0.3.0"
-    supports-color "^0.2.0"
 
 chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -1209,8 +1191,8 @@ chokidar@^1.6.1:
     fsevents "^1.0.0"
 
 chokidar@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.3.tgz#dcbd4f6cbb2a55b4799ba8a840ac527e5f4b1176"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.0"
@@ -1219,12 +1201,13 @@ chokidar@^2.0.2:
     inherits "^2.0.1"
     is-binary-path "^1.0.0"
     is-glob "^4.0.0"
+    lodash.debounce "^4.0.8"
     normalize-path "^2.1.1"
     path-is-absolute "^1.0.0"
     readdirp "^2.0.0"
-    upath "^1.0.0"
+    upath "^1.0.5"
   optionalDependencies:
-    fsevents "^1.1.2"
+    fsevents "^1.2.2"
 
 chownr@^1.0.1:
   version "1.0.1"
@@ -1411,13 +1394,14 @@ concat-stream@1.6.2, concat-stream@^1.5.0, concat-stream@^1.6.0:
     typedarray "^0.0.6"
 
 concurrently@^3.5.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-3.5.1.tgz#ee8b60018bbe86b02df13e5249453c6ececd2521"
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-3.6.0.tgz#c25e34b156a9d5bd4f256a0d85f6192438ae481f"
   dependencies:
-    chalk "0.5.1"
+    chalk "^2.4.1"
     commander "2.6.0"
     date-fns "^1.23.0"
     lodash "^4.5.1"
+    read-pkg "^3.0.0"
     rx "2.3.24"
     spawn-command "^0.0.2-1"
     supports-color "^3.2.3"
@@ -1514,10 +1498,10 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     sha.js "^2.4.8"
 
 cross-env@^5.0.2:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.6.tgz#0dc05caf945b24e4b9e3b12871fe0e858d08b38d"
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
   dependencies:
-    cross-spawn "^5.1.0"
+    cross-spawn "^6.0.5"
     is-windows "^1.0.0"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
@@ -1525,6 +1509,16 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -1891,8 +1885,8 @@ ecstatic@^3.2.0:
     url-join "^2.0.2"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.47:
-  version "1.3.48"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz#d3b0d8593814044e092ece2108fc3ac9aea4b900"
+  version "1.3.50"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz#7438b76f92b41b919f3fbdd350fbd0757dacddf7"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -1941,9 +1935,9 @@ errno@^0.1.3, errno@~0.1.7:
   dependencies:
     prr "~1.0.1"
 
-error-ex@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+error-ex@^1.2.0, error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
@@ -2018,7 +2012,7 @@ es6-weak-map@^2.0.1:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
 
-escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -2063,8 +2057,8 @@ eslint-module-utils@^2.2.0:
     pkg-dir "^1.0.0"
 
 eslint-plugin-import@^2.2.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz#df24f241175e312d91662dc91ca84064caec14ed"
   dependencies:
     contains-path "^0.1.0"
     debug "^2.6.8"
@@ -2506,7 +2500,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.0.0, fsevents@^1.1.2:
+fsevents@^1.0.0, fsevents@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
@@ -2594,8 +2588,8 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     path-is-absolute "^1.0.0"
 
 globals@^11.0.1:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -2643,7 +2637,7 @@ handlebars@^4.0.3:
 
 "handsontable@github:handsontable/handsontable#develop":
   version "4.0.0"
-  resolved "https://codeload.github.com/handsontable/handsontable/tar.gz/1c441de2693b18bc48faac46f7bc8cf591d052fc"
+  resolved "https://codeload.github.com/handsontable/handsontable/tar.gz/bd17971c3a3712ed4bdc3d5e7c5e10abbea3e129"
   dependencies:
     moment "2.20.1"
     numbro "^2.0.6"
@@ -2659,12 +2653,6 @@ har-validator@~5.0.3:
   dependencies:
     ajv "^5.1.0"
     har-schema "^2.0.0"
-
-has-ansi@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-0.1.0.tgz#84f265aae8c0e6a88a12d7022894b7568894c62e"
-  dependencies:
-    ansi-regex "^0.2.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -2764,7 +2752,7 @@ hosted-git-info@^2.1.4:
 
 hot-formula-parser@^2.3.1:
   version "2.3.3"
-  resolved "http://npm.handsoncode:4873/hot-formula-parser/-/hot-formula-parser-2.3.3.tgz#a7f3f8d2d8ea8d68c409c2df4e362f29e37b604d"
+  resolved "https://registry.yarnpkg.com/hot-formula-parser/-/hot-formula-parser-2.3.3.tgz#a7f3f8d2d8ea8d68c409c2df4e362f29e37b604d"
   dependencies:
     "@handsontable/formulajs" "^1.2.3"
     tiny-emitter "^2.0.1"
@@ -2865,8 +2853,8 @@ ignore-walk@^3.0.1:
     minimatch "^3.0.4"
 
 ignore@^3.3.3, ignore@^3.3.5:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -3536,6 +3524,10 @@ json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
 
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
@@ -3662,6 +3654,15 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
@@ -3693,6 +3694,10 @@ locate-path@^2.0.0:
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
 lodash.flatten@^4.4.0:
   version "4.4.0"
@@ -3985,6 +3990,10 @@ next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -4033,8 +4042,8 @@ node-notifier@^5.0.1:
     which "^1.3.0"
 
 node-pre-gyp@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz#6e4ef5bb5c5203c6552448828c852c40111aac46"
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.2.tgz#e8945c20ef6795a20aac2b44f036eb13cf5146e3"
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -4042,7 +4051,7 @@ node-pre-gyp@^0.10.0:
     nopt "^4.0.1"
     npm-packlist "^1.1.6"
     npmlog "^4.0.2"
-    rc "^1.1.7"
+    rc "^1.2.7"
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
@@ -4124,11 +4133,11 @@ number-is-nan@^1.0.0:
 
 numbro@^1.11.0:
   version "1.11.1"
-  resolved "http://npm.handsoncode:4873/numbro/-/numbro-1.11.1.tgz#e0d9ba0ddfc3ad5ac01d9558a49383db214f04be"
+  resolved "https://registry.yarnpkg.com/numbro/-/numbro-1.11.1.tgz#e0d9ba0ddfc3ad5ac01d9558a49383db214f04be"
 
 numbro@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/numbro/-/numbro-2.0.6.tgz#d46acaa11aa879d522e93651de3926646d6db100"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/numbro/-/numbro-2.1.0.tgz#618ac6e4b2f32f2e623190ce4b05f4c8b09c3207"
   dependencies:
     bignumber.js "^4.0.4"
 
@@ -4157,8 +4166,8 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-keys@^1.0.11, object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -4333,6 +4342,13 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
@@ -4367,7 +4383,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -4699,8 +4715,8 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     supports-color "^3.2.3"
 
 postcss@^6.0.1:
-  version "6.0.22"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
+  version "6.0.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   dependencies:
     chalk "^2.4.1"
     source-map "^0.6.1"
@@ -4873,7 +4889,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-rc@^1.1.7:
+rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
@@ -4911,6 +4927,14 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
+
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.6"
@@ -5113,8 +5137,8 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.2.0, resolve@^1.5.0, resolve@^1.6.0:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
 
@@ -5210,7 +5234,7 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -5502,12 +5526,6 @@ string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-strip-ansi@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.3.0.tgz#25f48ea22ca79187f3174a4db8759347bb126220"
-  dependencies:
-    ansi-regex "^0.2.1"
-
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -5550,10 +5568,6 @@ style-loader@^0.8.3:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.8.3.tgz#f4f92eb7db63768748f15065cd6700f5a1c85357"
   dependencies:
     loader-utils "^0.2.5"
-
-supports-color@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -5810,8 +5824,8 @@ unique-slug@^2.0.0:
     imurmurhash "^0.1.4"
 
 universalify@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -5820,7 +5834,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.0.0:
+upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
@@ -6059,8 +6073,8 @@ write@^0.2.1:
     mkdirp "^0.5.1"
 
 ws@^5.1.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.0.tgz#9fd95e3ac7c76f6ae8bcc868a0e3f11f1290c33e"
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.1.tgz#37827a0ba772d072a843c3615b0ad38bcdb354eb"
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
### Context
Adding ability to modify BOM in file exporting.

### How has this been tested?
On macOS env you can use below commands:
- `file -I file.csv` - to check mime-type and charset
- `hexdump file.csv` - to verify BOM is prepended to file

### Types of changes
- [x] New feature or improvement (a non-breaking change which adds functionality)

### Related issue(s):
1. #85
