### PR TITLE
ESLINT - linebreak-style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -60,7 +60,6 @@
     "prefer-template": 1,
     "space-infix-ops": 2,
     "vars-on-top": 0,
-    "linebreak-style": 0,
     "camelcase": [
       2,
       {


### PR DESCRIPTION
### Context
Necessary changes to remove `linebreak-style` from our custom `.eslintrc`.

### How has this been tested?
1. `npm run lint`
2. should be error-free

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #107