### PR TITLE
ESLINT - no-extra-semi

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,6 @@
     "new-cap": 2,
     "newline-per-chained-call": 1,
     "no-eq-null": 1,
-    "no-extra-semi": 0,
     "no-irregular-whitespace": 2,
     "no-mixed-spaces-and-tabs": 2,
     "no-multi-str": 2,

--- a/src/plugins/exportFile/test/types/csv.e2e.js
+++ b/src/plugins/exportFile/test/types/csv.e2e.js
@@ -3,7 +3,7 @@ describe('exportFile CSV type', () => {
 
   function data(x, y) {
     return Handsontable.helper.createSpreadsheetData(x, y);
-  };
+  }
 
   function countLines(str) {
     const lines = str.split('\r\n');

--- a/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
+++ b/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
@@ -223,7 +223,7 @@ describe('HiddenColumns', function() {
       setData(type, value) {
         this.data = value;
       }
-    };
+    }
 
     function getClipboardEvent() {
       let event = {};

--- a/src/plugins/hiddenRows/test/hiddenRows.e2e.js
+++ b/src/plugins/hiddenRows/test/hiddenRows.e2e.js
@@ -278,7 +278,7 @@ describe('HiddenRows', function() {
       setData(type, value) {
         this.data = value;
       }
-    };
+    }
 
     function getClipboardEvent() {
       let event = {};

--- a/src/plugins/trimRows/test/trimRows.e2e.js
+++ b/src/plugins/trimRows/test/trimRows.e2e.js
@@ -281,7 +281,7 @@ describe('TrimRows', function() {
       setData(type, value) {
         this.data = value;
       }
-    };
+    }
 
     function getClipboardEvent() {
       let event = {};

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -4,11 +4,11 @@ export function sleep(delay = 100) {
       setTimeout(resolve, delay);
     }
   });
-};
+}
 
 export function hot() {
   return spec().$container.data('handsontable');
-};
+}
 
 export function handsontable(options) {
   var currentSpec = spec();
@@ -17,7 +17,7 @@ export function handsontable(options) {
   currentSpec.$container[0].focus(); // otherwise TextEditor tests do not pass in IE8
 
   return currentSpec.$container.data('handsontable');
-};
+}
 
 /**
  * As for v. 0.11 the only scrolling method is native scroll, which creates copies of main htCore table inside of the container.
@@ -31,46 +31,46 @@ export function handsontable(options) {
 
 export function getMaster() {
   return spec().$container.find('.ht_master');
-};
+}
 
 export function getHtCore() {
   return spec().$container.find('.htCore').first();
-};
+}
 
 export function getTopClone() {
   return spec().$container.find('.ht_clone_top');
-};
+}
 
 export function getTopLeftClone() {
   return spec().$container.find('.ht_clone_top_left_corner');
-};
+}
 // for compatybility
 // var getCornerClone = getTopLeftClone;
 
 export function getLeftClone() {
   return spec().$container.find('.ht_clone_left');
-};
+}
 
 export function getBottomClone() {
   return spec().$container.find('.ht_clone_bottom');
-};
+}
 
 export function getBottomLeftClone() {
   return spec().$container.find('.ht_clone_bottom_left_corner');
-};
+}
 
 // Rename me to countTD
 export function countCells() {
   return getHtCore().find('tbody td').length;
-};
+}
 
 export function isEditorVisible() {
   return !!(keyProxy().is(':visible') && keyProxy().parent().is(':visible') && !keyProxy().parent().is('.htHidden'));
-};
+}
 
 export function isFillHandleVisible() {
   return !!spec().$container.find('.wtBorder.corner:visible').length;
-};
+}
 
 export function getCorrespondingOverlay(cell, container) {
   var overlay = $(cell).parents('.handsontable');
@@ -80,7 +80,7 @@ export function getCorrespondingOverlay(cell, container) {
   }
 
   return $(overlay[0]);
-};
+}
 
 /**
  * Shows context menu
@@ -102,12 +102,12 @@ export function contextMenu(cell) {
     clientX: cellOffset.left - Handsontable.dom.getWindowScrollLeft(),
     clientY: cellOffset.top - Handsontable.dom.getWindowScrollTop(),
   });
-};
+}
 
 export function closeContextMenu() {
   $(document).simulate('mousedown');
   //  $(document).trigger('mousedown');
-};
+}
 
 /**
  * Shows dropdown menu
@@ -121,11 +121,11 @@ export function dropdownMenu(columnIndex) {
     $(button).simulate('mousedown');
     $(button).simulate('click');
   }
-};
+}
 
 export function closeDropdownMenu() {
   $(document).simulate('mousedown');
-};
+}
 
 export function dropdownMenuRootElement() {
   var plugin = hot().getPlugin('dropdownMenu');
@@ -136,7 +136,7 @@ export function dropdownMenuRootElement() {
   }
 
   return root;
-};
+}
 
 /**
  * Returns a function that triggers a mouse event
@@ -153,7 +153,7 @@ export function handsontableMouseTriggerFactory(type, button) {
 
     element.simulate(type, ev);
   };
-};
+}
 
 export const mouseDown = handsontableMouseTriggerFactory('mousedown');
 export const mouseMove = handsontableMouseTriggerFactory('mousemove');
@@ -165,7 +165,7 @@ export function mouseDoubleClick(element) {
   mouseUp(element);
   mouseDown(element);
   mouseUp(element);
-};
+}
 
 export const mouseRightDown = handsontableMouseTriggerFactory('mousedown', 3);
 export const mouseRightUp = handsontableMouseTriggerFactory('mouseup', 3);
@@ -266,7 +266,7 @@ export function handsontableKeyTriggerFactory(type) {
     $.extend(ev, extend);
     $(document.activeElement).simulate(type, ev);
   };
-};
+}
 
 export const keyDown = handsontableKeyTriggerFactory('keydown');
 export const keyUp = handsontableKeyTriggerFactory('keyup');
@@ -285,7 +285,7 @@ export function keyDownUp(key, extend) {
   if (typeof key === 'string' && key.indexOf('shift+') > -1) {
     keyUp('shift');
   }
-};
+}
 
 /**
  * Returns current value of the keyboard proxy textarea
@@ -293,7 +293,7 @@ export function keyDownUp(key, extend) {
  */
 export function keyProxy() {
   return spec().$container.find('textarea.handsontableInput');
-};
+}
 
 export function serveImmediatePropagation(event) {
   if (event != null && event.isImmediatePropagationEnabled == null) {
@@ -308,11 +308,11 @@ export function serveImmediatePropagation(event) {
   }
 
   return event;
-};
+}
 
 export function autocompleteEditor() {
   return spec().$container.find('.handsontableInput');
-};
+}
 
 /**
  * Sets text cursor inside keyboard proxy
@@ -330,21 +330,21 @@ export function setCaretPosition(pos) {
     range.moveStart('character', pos);
     range.select();
   }
-};
+}
 
 /**
  * Returns autocomplete instance
  */
 export function autocomplete() {
   return spec().$container.find('.autocompleteEditor');
-};
+}
 
 /**
  * Triggers paste string on current selection
  */
 export function triggerPaste(str) {
   spec().$container.data('handsontable').copyPaste.triggerPaste(null, str);
-};
+}
 
 /**
  * Calls a method in current Handsontable instance, returns its output
@@ -373,7 +373,7 @@ export function handsontableMethodFactory(method) {
 
     return instance[method](...arguments);
   };
-};
+}
 
 export const addHook = handsontableMethodFactory('addHook');
 export const alter = handsontableMethodFactory('alter');
@@ -714,4 +714,4 @@ export function triggerTouchEvent(type, target, pageX, pageY) {
 
   e.initTouchEvent(type, true, true, window, null, 0, 0, 0, 0, false, false, false, false, touches, targetTouches, changedTouches, 1, 0);
   target.dispatchEvent(e);
-};
+}

--- a/test/helpers/jasmine.js
+++ b/test/helpers/jasmine.js
@@ -3,7 +3,7 @@ var currentSpec;
 
 export function spec() {
   return currentSpec;
-};
+}
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
 


### PR DESCRIPTION
### Context
Necessary changes to remove `no-extra-semi` from our custom `.eslintrc`.

### How has this been tested?
1. `npm run lint`
2. should be error-free

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #107