### PR TITLE
ESLINT - no-unneeded-ternary

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -80,12 +80,6 @@
         ["+", "-", "*", "/", "%", "**"]
       ]
     ],
-    "no-unneeded-ternary": [
-      2,
-      {
-        "defaultAssignment": true
-      }
-    ],
     "no-confusing-arrow": [
       2,
       {


### PR DESCRIPTION
### Context
Necessary changes to remove `no-unneeded-ternary` from our custom `.eslintrc`.

### How has this been tested?
1. `npm run lint`
2. should be error-free

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #107