### PR TITLE
ESLINT - prefer-rest-params

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,6 @@
     "one-var": 0,
     "padded-blocks": 0,
     "prefer-const": 0,
-    "prefer-rest-params": 1,
     "space-infix-ops": 2,
     "vars-on-top": 0,
     "camelcase": [

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -352,7 +352,7 @@ export function triggerPaste(str) {
  * @return {Function}
  */
 export function handsontableMethodFactory(method) {
-  return function() {
+  return function(...args) {
     var instance;
     try {
       instance = spec().$container.handsontable('getInstance');
@@ -371,7 +371,7 @@ export function handsontableMethodFactory(method) {
       throw new Error('Something wrong with the test spec: Handsontable instance not found');
     }
 
-    return instance[method](...arguments);
+    return instance[method](...args);
   };
 }
 


### PR DESCRIPTION
### Context
Necessary changes to remove `prefer-rest-params` from our custom `.eslintrc`.

### How has this been tested?
1. `npm run lint`
2. should be error-free

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #107