### PR TITLE
ESLINT - vars-on-top

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,7 +53,6 @@
     "no-with": 2,
     "padded-blocks": 0,
     "space-infix-ops": 2,
-    "vars-on-top": 0,
     "camelcase": [
       2,
       {


### PR DESCRIPTION
### Context
Necessary changes to remove `vars-on-top` from our custom `.eslintrc`.

### How has this been tested?
1. `npm run lint`
2. should be error-free

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #107