### PR TITLE
ESLINT - no-restricted-properties

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,6 @@
       "error",
       { "allowForLoopAfterthoughts": true }
     ],
-    "no-restricted-properties": 0,
     "no-restricted-syntax": 1,
     "no-shadow": 1,
     "no-spaced-func": 2,

--- a/src/plugins/columnSummary/columnSummary.js
+++ b/src/plugins/columnSummary/columnSummary.js
@@ -174,7 +174,7 @@ class ColumnSummary extends BasePlugin {
     } while (i >= rowRange[0]);
 
     // Workaround for e.g. 802.2 + 1.1 = 803.3000000000001
-    return Math.round(sum * Math.pow(10, biggestDecimalPlacesCount)) / Math.pow(10, biggestDecimalPlacesCount);
+    return Math.round(sum * (10 ** biggestDecimalPlacesCount)) / (10 ** biggestDecimalPlacesCount);
   }
 
   /**


### PR DESCRIPTION
### Context
Necessary changes to remove `no-restricted-properties` from our custom `.eslintrc`.

### How has this been tested?
1. `npm run lint`
2. should be error-free

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #107 