### PR TITLE
[Multi-column sorting] New, inserted columns breaks the table

### DIFF
--- a/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -752,6 +752,7 @@ class MultiColumnSorting extends BasePlugin {
   }
 
   // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. We clear the cache after action which reorganize sequence of columns.
+  // TODO: Remove test named: "should add new columns properly when the `columnSorting` plugin is enabled (inheriting of non-primitive cell meta values)".
   /**
    * Callback for the `afterCreateCol` hook.
    *
@@ -762,6 +763,7 @@ class MultiColumnSorting extends BasePlugin {
   }
 
   // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. We clear the cache after action which reorganize sequence of columns.
+  // TODO: Remove test named: "should add new columns properly when the `columnSorting` plugin is enabled (inheriting of non-primitive cell meta values)".
   /**
    * Callback for the `afterRemoveCol` hook.
    *

--- a/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -161,6 +161,8 @@ class MultiColumnSorting extends BasePlugin {
     this.addHook('afterRemoveRow', (index, amount) => this.onAfterRemoveRow(index, amount));
     this.addHook('afterInit', () => this.loadOrSortBySettings());
     this.addHook('afterLoadData', initialLoad => this.onAfterLoadData(initialLoad));
+    this.addHook('afterCreateCol', () => this.onAfterCreateCol());
+    this.addHook('afterRemoveCol', () => this.onAfterRemoveCol());
 
     // TODO: Workaround? It should be refactored / described.
     if (this.hot.view) {
@@ -310,7 +312,7 @@ class MultiColumnSorting extends BasePlugin {
    *
    *   // const newData = ... // Calculated data set, ie. from an AJAX call.
    *
-   *   this.loadData(newData);
+   *   // this.loadData(newData); // Load new data set.
    *
    *   return false; // The blockade for the default sort action.
    * }```
@@ -579,6 +581,65 @@ class MultiColumnSorting extends BasePlugin {
   }
 
   /**
+   * Load saved settings or sort by predefined plugin configuration.
+   *
+   * @private
+   */
+  loadOrSortBySettings() {
+    this.columnMetaCache.clear();
+
+    const storedAllSortSettings = this.getAllSavedSortSettings();
+
+    if (isObject(storedAllSortSettings)) {
+      this.sortBySettings(storedAllSortSettings);
+
+    } else {
+      const allSortSettings = this.hot.getSettings().multiColumnSorting;
+
+      this.sortBySettings(allSortSettings);
+    }
+  }
+
+  /**
+   * Sort the table by provided configuration.
+   *
+   * @private
+   * @param {Object} allSortSettings All sort config settings. Object may contain `initialConfig`, `indicator`,
+   * `sortEmptyCells`, `headerAction` and `compareFunctionFactory` properties.
+   */
+  sortBySettings(allSortSettings) {
+    if (isObject(allSortSettings)) {
+      this.columnStatesManager.updateAllColumnsProperties(allSortSettings);
+
+      const initialConfig = allSortSettings.initialConfig;
+
+      if (Array.isArray(initialConfig) || isObject(initialConfig)) {
+        this.sort(initialConfig);
+      }
+
+    } else {
+      // Extra render for headers. Their width may change.
+      this.hot.render();
+    }
+  }
+
+  /**
+   * Enables the ObserveChanges plugin.
+   *
+   * @private
+   */
+  enableObserveChangesPlugin() {
+    const _this = this;
+
+    this.hot._registerTimeout(
+      setTimeout(() => {
+        _this.hot.updateSettings({
+          observeChanges: true
+        });
+      }, 0));
+  }
+
+  /**
    * Callback for `modifyRow` hook. Translates visual row index to the sorted row index.
    *
    * @private
@@ -652,64 +713,6 @@ class MultiColumnSorting extends BasePlugin {
   }
 
   /**
-   * Load saved settings or sort by predefined plugin configuration.
-   *
-   * @private
-   */
-  loadOrSortBySettings() {
-    this.columnMetaCache.clear();
-
-    const storedAllSortSettings = this.getAllSavedSortSettings();
-
-    if (isObject(storedAllSortSettings)) {
-      this.sortBySettings(storedAllSortSettings);
-
-    } else {
-      const allSortSettings = this.hot.getSettings().multiColumnSorting;
-
-      this.sortBySettings(allSortSettings);
-    }
-  }
-
-  /**
-   * Sort the table by provided configuration.
-   *
-   * @private
-   * @param {Object} allSortSettings All sort config settings. Object may contain `initialConfig`, `indicator`,
-   * `sortEmptyCells`, `headerAction` and `compareFunctionFactory` properties.
-   */
-  sortBySettings(allSortSettings) {
-    if (isObject(allSortSettings)) {
-      this.columnStatesManager.updateAllColumnsProperties(allSortSettings);
-
-      const initialConfig = allSortSettings.initialConfig;
-
-      if (Array.isArray(initialConfig) || isObject(initialConfig)) {
-        this.sort(initialConfig);
-      }
-
-    } else {
-      // Extra render for headers. Their width may change.
-      this.hot.render();
-    }
-  }
-
-  /**
-   * Enables the ObserveChanges plugin.
-   *
-   * @private
-   */
-  enableObserveChangesPlugin() {
-    const _this = this;
-    this.hot._registerTimeout(
-      setTimeout(() => {
-        _this.hot.updateSettings({
-          observeChanges: true
-        });
-      }, 0));
-  }
-
-  /**
    * Callback for the `afterLoadData` hook.
    *
    * @private
@@ -746,6 +749,26 @@ class MultiColumnSorting extends BasePlugin {
    */
   onAfterRemoveRow(removedRows, amount) {
     this.rowsMapper.unshiftItems(removedRows, amount);
+  }
+
+  // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. We clear the cache after action which reorganize sequence of columns.
+  /**
+   * Callback for the `afterCreateCol` hook.
+   *
+   * @private
+   */
+  onAfterCreateCol() {
+    this.columnMetaCache.clear();
+  }
+
+  // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. We clear the cache after action which reorganize sequence of columns.
+  /**
+   * Callback for the `afterRemoveCol` hook.
+   *
+   * @private
+   */
+  onAfterRemoveCol() {
+    this.columnMetaCache.clear();
   }
 
   /**

--- a/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
+++ b/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
@@ -2903,21 +2903,6 @@ describe('MultiColumnSorting', () => {
 
   // TODO: Remove tests when workaround will be removed.
   describe('workaround regression check', () => {
-    it('should add new columns properly when the `columnSorting` plugin is enabled (inheriting of non-primitive cell meta values)', () => {
-      spec().$container[0].style.width = 'auto';
-      spec().$container[0].style.height = 'auto';
-
-      handsontable({
-        colHeaders: true,
-        data: Handsontable.helper.createSpreadsheetData(2, 2),
-        multiColumnSorting: true
-      });
-
-      alter('insert_col', 2, 5);
-
-      expect(getHtCore().find('tbody tr:eq(0) td').length).toEqual(7);
-    });
-
     it('should not break the dataset when inserted new row', () => {
       handsontable({
         colHeaders: true,
@@ -2933,6 +2918,21 @@ describe('MultiColumnSorting', () => {
         [null, null, null],
         ['A3', 'B3', 'C3']
       ]);
+    });
+
+    it('should add new columns properly when the `columnSorting` plugin is enabled (inheriting of non-primitive cell meta values)', () => {
+      spec().$container[0].style.width = 'auto';
+      spec().$container[0].style.height = 'auto';
+
+      handsontable({
+        colHeaders: true,
+        data: Handsontable.helper.createSpreadsheetData(2, 2),
+        multiColumnSorting: true
+      });
+
+      alter('insert_col', 2, 5);
+
+      expect(getHtCore().find('tbody tr:eq(0) td').length).toEqual(7);
     });
   });
 });

--- a/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
+++ b/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
@@ -2900,4 +2900,22 @@ describe('MultiColumnSorting', () => {
       expect(htCoreWidthAtStart).toBe(newHtCoreWidth);
     });
   });
+
+  // TODO: Remove tests when workaround will be removed.
+  describe('workaround regression check', () => {
+    it('should add new columns properly when the `columnSorting` plugin is enabled (inheriting of non-primitive cell meta values)', () => {
+      spec().$container[0].style.width = 'auto';
+      spec().$container[0].style.height = 'auto';
+
+      handsontable({
+        colHeaders: true,
+        data: Handsontable.helper.createSpreadsheetData(2, 2),
+        multiColumnSorting: true
+      });
+
+      alter('insert_col', 2, 5);
+
+      expect(getHtCore().find('tbody tr').length).toBeLessThan(7);
+    });
+  });
 });

--- a/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
+++ b/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
@@ -2915,7 +2915,7 @@ describe('MultiColumnSorting', () => {
 
       alter('insert_col', 2, 5);
 
-      expect(getHtCore().find('tbody tr').length).toBeLessThan(7);
+      expect(getHtCore().find('tbody tr:eq(0) td').length).toEqual(7);
     });
   });
 });


### PR DESCRIPTION
### Context
Fixed bug by adding extra listeners on `afterCreateCol`, `afterRemoveCol` hooks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #140 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
