### PR TITLE
[Multi-column sorting] New, inserted row breaks the table data

### DIFF
--- a/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -498,6 +498,9 @@ class MultiColumnSorting extends BasePlugin {
   // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. Instead of getting properties from
   // column meta we call this function.
   getFirstCellSettings(column) {
+    // TODO: Remove test named: "should not break the dataset when inserted new row" (#142).
+    const actualBlockTranslationFlag = this.blockPluginTranslation;
+
     this.blockPluginTranslation = true;
 
     if (this.columnMetaCache.size === 0) {
@@ -508,7 +511,7 @@ class MultiColumnSorting extends BasePlugin {
 
     const cellMeta = this.hot.getCellMeta(0, column);
 
-    this.blockPluginTranslation = false;
+    this.blockPluginTranslation = actualBlockTranslationFlag;
 
     const cellMetaCopy = Object.create(cellMeta);
     cellMetaCopy.multiColumnSorting = this.columnMetaCache.get(this.hot.toPhysicalColumn(column));

--- a/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
+++ b/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
@@ -2900,4 +2900,24 @@ describe('MultiColumnSorting', () => {
       expect(htCoreWidthAtStart).toBe(newHtCoreWidth);
     });
   });
+
+  // TODO: Remove tests when workaround will be removed.
+  describe('workaround regression check', () => {
+    it('should not break the dataset when inserted new row', () => {
+      handsontable({
+        colHeaders: true,
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        multiColumnSorting: true
+      });
+
+      alter('insert_row', 2);
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        [null, null, null],
+        ['A3', 'B3', 'C3']
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
### Context
Using `getFirstCellSettings` won't change plugin's `blockPluginTranslation` flag.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #142

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
