### PR TITLE
Remove external modules from jsdoc @Dependencies tag

### DIFF
--- a/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -84,7 +84,7 @@ const REPLACE_COLUMN_CONFIG_STRATEGY = 'replace';
  *   }
  * }]```
  *
- * @dependencies ObserveChanges moment
+ * @dependencies ObserveChanges
  */
 class MultiColumnSorting extends BasePlugin {
   constructor(hotInstance) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
[hot-builder](https://github.com/handsontable/hot-builder) no more supports 3rd parties dependencies defined as jsdoc tag @dependencies. This PR removes all unsupported modules.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
To test this PR clone the repo and try to build it using the latest version of hot-builder. Command to build files looks like `hot-builder build -i cloned-handsontable-pro/ -o hot-dist/`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/5287

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
