### PR TITLE
Add `beforePaste` hook to `trimRows`

### DIFF
--- a/src/plugins/trimRows/test/trimRows.e2e.js
+++ b/src/plugins/trimRows/test/trimRows.e2e.js
@@ -316,6 +316,38 @@ describe('TrimRows', () => {
         'A10	B10	C10	D10	E10	F10	G10	H10	I10	J10'
       );
     });
+
+    it('should create map and therefore new rows before past data', async() => {
+      const hot = handsontable({
+        data: [['', '']],
+        colHeaders: true,
+        columns: [
+          {
+            type: 'date',
+            dateFormat: 'MM/DD/YYYY',
+            correctFormat: true,
+            defaultDate: '01/01/1900'
+          },
+          {
+            type: 'time',
+            timeFormat: 'h:mm:ss a',
+            correctFormat: true
+          },
+        ],
+        trimRows: true,
+      });
+
+      const dateData = '2/5/2018\n2/11/2018\n2/11/2018\n2/11/2018\n2/5/2018\n22/11/2018\n2/5/2018\n2/5/2018\n22/5/2018';
+      const plugin = hot.getPlugin('CopyPaste');
+
+      selectCell(0, 0);
+
+      plugin.paste(dateData);
+
+      await sleep(200);
+
+      expect(hot.getData().length).toEqual(9);
+    });
   });
 
   describe('navigation', () => {

--- a/src/plugins/trimRows/trimRows.js
+++ b/src/plugins/trimRows/trimRows.js
@@ -103,6 +103,7 @@ class TrimRows extends BasePlugin {
     this.addHook('afterCreateRow', (index, amount) => this.onAfterCreateRow(index, amount));
     this.addHook('beforeRemoveRow', (index, amount) => this.onBeforeRemoveRow(index, amount));
     this.addHook('afterRemoveRow', () => this.onAfterRemoveRow());
+    this.addHook('beforePaste', data => this.onBeforePaste(data));
     this.addHook('afterLoadData', firstRun => this.onAfterLoadData(firstRun));
 
     super.enablePlugin();
@@ -294,6 +295,16 @@ class TrimRows extends BasePlugin {
    */
   onAfterRemoveRow() {
     this.rowsMapper.unshiftItems(this.removedRows);
+  }
+
+  /**
+   * `beforePaste` hook callback.
+   *
+   * @private
+   * @param {Array} data An array of arrays which contains data to paste.
+   */
+  onBeforePaste(data) {
+    this.rowsMapper.createMap(data.length);
   }
 
   /**


### PR DESCRIPTION
### Context
Add `beforePaste` hook to `trimRows`, because without it `dateValidator` and `timeValidator` have only one row after paste action. The rest have `null` after  `unmodifyRow`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #181 
2. handsontable/handsontable#5565

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
