### PR TITLE
Performance improvements for Nested Rows expandAll(), collapseAll(), and untrimRows()

### DIFF
--- a/src/plugins/nestedRows/ui/collapsing.js
+++ b/src/plugins/nestedRows/ui/collapsing.js
@@ -105,10 +105,10 @@ class CollapsingUI extends BaseUI {
    * @param {Boolean} [doTrimming = true] `true` if the table should trim the provided rows.
    */
   collapseMultipleChildren(rows, forceRender = true, doTrimming = true) {
-    let rowsToTrim = [];
+    const rowsToTrim = [];
 
     arrayEach(rows, (elem) => {
-      rowsToTrim = rowsToTrim.concat(this.collapseChildren(elem, false, false));
+      rowsToTrim.push(...this.collapseChildren(elem, false, false));
     });
 
     if (doTrimming) {
@@ -292,10 +292,10 @@ class CollapsingUI extends BaseUI {
    * @param {Boolean} [doTrimming = true] `true` if the rows should be untrimmed after finishing the function.
    */
   expandMultipleChildren(rows, forceRender = true, doTrimming = true) {
-    let rowsToUntrim = [];
+    const rowsToUntrim = [];
 
     arrayEach(rows, (elem) => {
-      rowsToUntrim = rowsToUntrim.concat(this.expandChildren(elem, false, false));
+      rowsToUntrim.push(...this.expandChildren(elem, false, false));
     });
 
     if (doTrimming) {

--- a/src/plugins/trimRows/trimRows.js
+++ b/src/plugins/trimRows/trimRows.js
@@ -170,13 +170,8 @@ class TrimRows extends BasePlugin {
    * @fires Hooks#afterUntrimRow
    */
   untrimRows(rows) {
-    arrayEach(rows, (row) => {
-      const physicalRow = parseInt(row, 10);
-
-      if (this.isTrimmed(physicalRow)) {
-        this.trimmedRows.splice(this.trimmedRows.indexOf(physicalRow), 1);
-      }
-    });
+    const parsedRows = rows.map(row => parseInt(row, 10));
+    this.trimmedRows = this.trimmedRows.filter(row => parsedRows.indexOf(row) === -1);
 
     this.hot.runHooks('skipLengthCache', 100);
     this.rowsMapper.createMap(this.hot.countSourceRows());


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Performance improvements for nested rows `collapseAll()` and `expandAll()` per https://github.com/handsontable/handsontable/issues/5711

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
`npm run test:e2e`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/5711
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
